### PR TITLE
Update expected version of `javascriptcoregtk` from 4.0 to 4.1

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -5,5 +5,5 @@ fn main() {
 
 #[cfg(target_os = "linux")]
 fn main() {
-    pkg_config::probe_library("javascriptcoregtk-4.0").unwrap();
+    pkg_config::probe_library("javascriptcoregtk-4.1").unwrap();
 }


### PR DESCRIPTION
In https://github.com/wasmerio/wasmer/pull/5999 Wasmer has moved its pinned version of `javascriptcoregtk` to 4.1 since 4.0 has reached end of life in nixpkgs.

Unfortunately, that breaks this package, since 4.0 is no longer available in the environment.

Let's update the expected version to 4.1.